### PR TITLE
feat: Publish gh-pages by site-deploy target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,6 @@ _site-generate:
 
 _site-clone:
 	@mkdir -p target/site
-	@git -C target/site clone --branch gh-pages --single-branch --depth 1 https://github.com/dakusui/insdog.git en
+	@git -C target/site clone --branch gh-pages --single-branch --depth 1 https://github.com/moneyforward/insdog.git en
 	@git -C target/site/en checkout gh-pages
 

--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,14 @@ release:
 	@$(MVN) release:perform
 
 ## Generate a site of this product under `target/site` directory.
-site:
-	@$(MVN_WITH_JAVADOC) clean compile site
-	@./src/build_tools/render-md-into-html.sh src/site/markdown target/site src/site/resources/html
-	@./src/build_tools/mangle-javadoc-html-files.sh target/site/en
+site: clean _site-generate
+	:
+
+## Generate a site of this product under `target/site` directory and publish it to `gh-pages` branch.
+site-deploy: clean _site-clone _site-generate
+	@git -C target/site/en add --all
+	@git -C target/site/en commit -a -m "Update site: $$(date)"
+	@git -C target/site/en push origin gh-pages
 
 # Generate Javadoc under `target/site/apidocs` dir.
 # Deprecated. Use `site` instead.
@@ -60,3 +64,17 @@ build: package
 ## Show help.
 help:
 	make2help $(MAKEFILE_LIST)
+
+
+# private targets
+_site-generate:
+	@rm -fr target/site/en/*
+	@$(MVN_WITH_JAVADOC) compile site
+	@./src/build_tools/render-md-into-html.sh src/site/markdown target/site src/site/resources/html
+	@./src/build_tools/mangle-javadoc-html-files.sh target/site/en
+
+_site-clone:
+	@mkdir -p target/site
+	@git -C target/site clone --branch gh-pages --single-branch --depth 1 https://github.com/dakusui/insdog.git en
+	@git -C target/site/en checkout gh-pages
+


### PR DESCRIPTION
Hi!
This is a pull request to add a gh-page based documentation site.
You can deploy your web site by doing `make-site-deploy`.
The site will look like this: https://dakusui.github.io/insdog/ (Doesn't it look cool?)

Before trying this feature you need to create `gh-pages` branch on your remote GitHub repo by doing for example:
```
 git checkout --orphan gh-pages
 rm -fr ./* .idea/ .github/
 touch README.md
 git add README.md 
 git commit -a -m 'Initial commit'
 git push -u origin gh-pages:gh-pages
```

Also, please ensure your `gh-pages` is enabled. (I know your company's policy, but don't worry and don't forget **InsDog** is already open-sourced!)

![Screenshot from 2025-03-12 07-52-54](https://github.com/user-attachments/assets/32b5d465-f2fb-40d6-a859-ef4cc75607c1)
