### PR TITLE
chore: pin GitHub Actions to SHA (action_sha_pining_github_leak_2026)

### DIFF
--- a/.github/workflows/build-and-verify.yml
+++ b/.github/workflows/build-and-verify.yml
@@ -49,14 +49,14 @@ jobs:
             libsidplay1v5
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Export environment variables
         run: |
           echo "JAVA_TOOL_OPTIONS=\"-Duser.home=${HOME}\"" >> $GITHUB_ENV
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: 'temurin'  # AdoptOpenJDK is now Eclipse Temurin
           java-version: '21'


### PR DESCRIPTION
## Summary
Replaces tag/branch references in workflow files with commit SHAs.

- Third-party actions are pinned via [pinact](https://github.com/suzuki-shunsuke/pinact).
- `moneyforward/*` actions are pinned to the latest commit SHA of whatever
  ref is currently specified (version tag or branch).

## Why
Mitigates the supply-chain risk of mutable tag/branch references in
GitHub Actions. SHAs are immutable; tags are not.

## Test plan
- [ ] CI green
- [ ] Workflow files diff-reviewed for unintended changes
